### PR TITLE
Allow post requests to smart focus to allow usage of dynamic content blocks.

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,6 +82,8 @@ as it implements a very simple Api\Http\ClientInterface.
 ##### Notification REST
 
 - [send($email, $encrypt, $notificationId, $random, $dyn, $senddate, $uidkey, $stype)] (#notificationsendemail-encrypt-notificationid-random-dyn-senddate-uidkey-stype)
+- buildTransactionalRequestObject($recipientEmail, $encryptId, $randomId, $dyn, $content, $enableTracking, $additionalParams)
+- post(SimpleXMLElement $xmlRequestObject)
 
 ### API Examples
 
@@ -224,7 +226,54 @@ $response = $api->send(
     'NOTHING'             // optional, The type of synchronization
 );
 ```
+### Notification::post(SimpleXMLElement $xmlRequestObject)
+```php
+// cURL client for communication with API
+use Estina\SmartFocus\Api\Http\CurlClient;
+// Member REST API class
+use Estina\SmartFocus\Api\Rest\Notification;
 
+// initialize object, injecting the cURL client
+$api = new Notification(new CurlClient());
+
+$recipientEmail = 'email@example.com';
+$encryptId = 'abcdefg';
+$randomId = '132456';
+
+$additionalParams = array(
+    'YYYY-MM-DD HH:MM:SS'
+    'email'
+    'NOTHING'
+);
+
+// Optional: Dynamic parameters as an array
+$dyn = array(
+    'firstname' => 'John',
+    'lastname' => 'Smith'
+);
+
+$content = array(
+    'click <a href="http://somewhere.com">here</a> please',
+    'good stuff is available <a href="http://goodstuff.com">here</a>'
+);
+
+// Tracking enabled for the links passed in the content blocks.
+$enableTracking = true;
+
+// Build request object.
+$xmlRequestObject = $api->buildTransactionalRequestObject(
+    $recipientEmail,
+    $encryptId,
+    $randomId,
+    $dyn,
+    $content,
+    $enableTracking,
+    $additionalParams
+);
+
+// Make the request.
+$response = $api->post($xmlRequestObject);
+```
 
 ## Troubleshooting
 

--- a/composer.json
+++ b/composer.json
@@ -7,12 +7,19 @@
             "name": "Mindaugas Liubinas",
             "email": "mindaugas.l@estina.lt",
             "homepage": "http://www.estina.com/"
+        },
+        {
+            "name": "Abdul Qureshi",
+            "email": "abdul@easyfundraising.org.uk"
         }
     ],
     "minimum-stability": "dev",
     "require": {
         "php": ">=5.3.0",
         "ext-curl": "*"
+    },
+    "require-dev": {
+        "phpunit/phpunit": "~4.7"
     },
     "autoload": {
         "psr-0" : {

--- a/composer.json
+++ b/composer.json
@@ -7,10 +7,6 @@
             "name": "Mindaugas Liubinas",
             "email": "mindaugas.l@estina.lt",
             "homepage": "http://www.estina.com/"
-        },
-        {
-            "name": "Abdul Qureshi",
-            "email": "abdul@easyfundraising.org.uk"
         }
     ],
     "minimum-stability": "dev",

--- a/src/Estina/SmartFocus/Api/Http/CurlClient.php
+++ b/src/Estina/SmartFocus/Api/Http/CurlClient.php
@@ -2,10 +2,9 @@
 
 namespace Estina\SmartFocus\Api\Http;
 
-use Estina\SmartFocus\Api\Http\ClientInterface;
 
 /**
- * Simple object oriented cURL wrapper
+ * Simple object oriented cURL wrapper.
  *
  * @license MIT License (http://www.opensource.org/licenses/mit-license.php)
  */
@@ -15,7 +14,7 @@ class CurlClient implements ClientInterface
     private $timeout;
 
     /**
-     * Constructor
+     * Constructor.
      *
      * @param int $timeout The maximum number of seconds to allow cURL functions to execute, default - 10
      */
@@ -45,7 +44,7 @@ class CurlClient implements ClientInterface
     }
 
     /**
-     * Performs GET request
+     * Performs GET request.
      *
      * @param string $url URL
      *
@@ -61,7 +60,7 @@ class CurlClient implements ClientInterface
     }
 
     /**
-     * Performs POST request
+     * Performs POST request.
      *
      * @param string $url URL
      * @param string $xml XML request body
@@ -78,12 +77,13 @@ class CurlClient implements ClientInterface
             'Accept: application/xml'
         ));
         $response = curl_exec($ch);
+        curl_close($ch);
 
         return $response;
     }
 
     /**
-     * Performs PUT request
+     * Performs PUT request.
      *
      * @param string $url    URL
      * @param array  $header Header
@@ -101,12 +101,13 @@ class CurlClient implements ClientInterface
         curl_setopt($ch, CURLOPT_CUSTOMREQUEST, "PUT");
         curl_setopt($ch, CURLOPT_POSTFIELDS, $body);
         $response = curl_exec($ch);
+        curl_close($ch);
 
         return $response;
     }
 
     /**
-     * Initializes cURL session and sets common options
+     * Initializes cURL session and sets common options.
      *
      * @param string $url
      *

--- a/src/Estina/SmartFocus/Api/Rest/Notification.php
+++ b/src/Estina/SmartFocus/Api/Rest/Notification.php
@@ -79,32 +79,41 @@ class Notification extends AbstractRestService
     /**
      * Builds up a transactional xml request object for batch processing.
      *
-     * @param array $params The mail parameters.
+     * @param string $recipientEmail The recipient email.
+     * @param string $encryptId The encrypt id for the template.
+     * @param string $randomId The random id for the template.
      * @param array|null $dyn The dynamic content.
      * @param array|null $content The content block links.
      * @param bool $enableTracking Set EMV URL in the urls found?
+     * @param array $additionalParams Any additional params to send off.
      *
      * @return SimpleXMLElement
      */
-    public function buildTransactionalRequestObject(array $params, array $dyn = null, array $content = null, $enableTracking = false)
-    {
+    public function buildTransactionalRequestObject(
+        $recipientEmail,
+        $encryptId,
+        $randomId,
+        array $dyn = null,
+        array $content = null,
+        $enableTracking = false,
+        array $additionalParams = null
+    ) {
         $xmlObject = new SimpleXMLElement('<MultiSendRequest></MultiSendRequest>');
 
-        $send_request = $xmlObject->addChild('sendrequest');
+        $sendRequest = $xmlObject->addChild('sendrequest');
+        $sendRequest->addChild('email');
+        $xmlObject->sendrequest->email = $recipientEmail;
+        $sendRequest->addChild('encrypt');
+        $xmlObject->sendrequest->encrypt = $encryptId;
+        $sendRequest->addChild('random');
+        $xmlObject->sendrequest->random = $randomId;
 
-        $send_request->addChild('email');
-        $send_request->addChild('encrypt');
-        $send_request->addChild('random');
-        $send_request->addChild('senddate');
-        $send_request->addChild('synchrotype');
-        $send_request->addChild('uidkey');
-
-        $xmlObject->sendrequest->encrypt = $params['encrypt'];
-        $xmlObject->sendrequest->random = $params['random'];
-        $xmlObject->sendrequest->email = $params['email'];
-        $xmlObject->sendrequest->senddate = $params['send_date'];
-        $xmlObject->sendrequest->synchrotype = $params['synchro_type'];
-        $xmlObject->sendrequest->uidkey = $params['uid_key'];
+        if (is_array($additionalParams)) {
+            foreach ($additionalParams as $key => $value) {
+                $sendRequest->addChild($key);
+                $sendRequest->$key = $value;
+            }
+        }
 
         if (is_array($dyn)) {
             $this->setDynInXMLObject($xmlObject->sendrequest, $dyn);
@@ -131,7 +140,6 @@ class Notification extends AbstractRestService
 
         // Add dyn tags to the request object.
         foreach ($dyn as $key => $value) {
-            $v = str_replace('£', '&pound;', $value);
             $entry = $xmlObject->dyn->addChild('entry');
             $entry->key = $key;
             $entry->value = $value;

--- a/src/Estina/SmartFocus/Api/Rest/Notification.php
+++ b/src/Estina/SmartFocus/Api/Rest/Notification.php
@@ -2,13 +2,22 @@
 
 namespace Estina\SmartFocus\Api\Rest;
 
+use Estina\SmartFocus\Api\Http\ClientInterface;
+use SimpleXMLElement;
+
 /**
- * Transactional Messaging Trigger API
+ * Transactional Messaging Trigger API.
  *
  * @license MIT License (http://www.opensource.org/licenses/mit-license.php)
  */
 class Notification extends AbstractRestService
 {
+    public function __construct(ClientInterface $client)
+    {
+        parent::__construct($client);
+
+        $this->setUrlPrefix('http://api.notificationmessaging.com');
+    }
 
     /**
      * @param string $email          The email address to which you wish to send the transactional message
@@ -32,9 +41,6 @@ class Notification extends AbstractRestService
         $uidkey = '',
         $stype = 'NOTHING'
     ) {
-
-        $this->setUrlPrefix('http://api.notificationmessaging.com');
-
         $params = array(
             'random' => $random,
             'encrypt' => $encrypt,
@@ -49,5 +55,117 @@ class Notification extends AbstractRestService
         );
 
         return $response;
+    }
+
+    /**
+     * Send batch of email transactions at once.
+     *
+     * Also supports sending of dynamic content.
+     *
+     * @param SimpleXMLElement $xmlObject The xml object to post.
+     *
+     * @return string|false XML response or FALSE on failure
+     */
+    public function post(SimpleXMLElement $xmlObject)
+    {
+        $response = $this->client->post(
+            $this->getUrl("NMSXML"),
+            $xmlObject->asXML()
+        );
+
+        return $response;
+    }
+
+    /**
+     * Builds up a transactional xml request object for batch processing.
+     *
+     * @param array $params The mail parameters.
+     * @param array|null $dyn The dynamic content.
+     * @param array|null $content The content block links.
+     * @param bool $enableTracking Set EMV URL in the urls found?
+     *
+     * @return SimpleXMLElement
+     */
+    public function buildTransactionalRequestObject(array $params, array $dyn = null, array $content = null, $enableTracking = false)
+    {
+        $xmlObject = new SimpleXMLElement('<MultiSendRequest></MultiSendRequest>');
+
+        $send_request = $xmlObject->addChild('sendrequest');
+
+        $send_request->addChild('email');
+        $send_request->addChild('encrypt');
+        $send_request->addChild('random');
+        $send_request->addChild('senddate');
+        $send_request->addChild('synchrotype');
+        $send_request->addChild('uidkey');
+
+        $xmlObject->sendrequest->encrypt = $params['encrypt'];
+        $xmlObject->sendrequest->random = $params['random'];
+        $xmlObject->sendrequest->email = $params['email'];
+        $xmlObject->sendrequest->senddate = $params['send_date'];
+        $xmlObject->sendrequest->synchrotype = $params['synchro_type'];
+        $xmlObject->sendrequest->uidkey = $params['uid_key'];
+
+        if (is_array($dyn)) {
+            $this->setDynInXMLObject($xmlObject->sendrequest, $dyn);
+        }
+
+        if (is_array($content)) {
+            $this->setContentInXMLObject($xmlObject->sendrequest, $content, $enableTracking);
+        }
+
+        return $xmlObject;
+    }
+
+    /**
+     * Sets the dyn tags in the xmlObject.
+     *
+     * @param datatype $xmlObject The xml object to set the dyn in.
+     * @param array $dyn The dyn tags.
+     *
+     * @return void
+     */
+    private function setDynInXMLObject($xmlObject, array $dyn)
+    {
+        $xmlObject->addChild('dyn');
+
+        // Add dyn tags to the request object.
+        foreach ($dyn as $key => $value) {
+            $v = str_replace('£', '&pound;', $value);
+            $entry = $xmlObject->dyn->addChild('entry');
+            $entry->key = $key;
+            $entry->value = $value;
+        }
+    }
+
+    /**
+     * Sets the content in the xmlObject.
+     *
+     * @param datatype $xmlObject The xml object to set the content in.
+     * @param array $content The dynamic content blocks to set.
+     * @param bool $enableTracking Set EMV URL in the urls found?
+     *
+     * @return void
+     */
+    private function setContentInXMLObject($xmlObject, array $content, $enableTracking)
+    {
+        $xmlObject->addChild('content');
+
+        // Html markup url expression.
+        $hrefExpr = '%href=([\'"])?((https?|ftp):\/\/[^\'" >]+)%i';
+
+        // Add Dynamic content blocks to the request object.
+        foreach ($content as $k => $v) {
+            if ($enableTracking) {
+                // Setup url tracking using emv tags.
+                $v = preg_replace($hrefExpr, 'href=$1[EMV URL]$2[EMV /URL]', $v);
+                // Replace the pound symbol for its htmlentity.
+                $v = str_replace('£', '&pound;', $v);
+            }
+
+            $entry = $xmlObject->content->addChild('entry');
+            $entry->key = $k;
+            $entry->value = $v;
+        }
     }
 }

--- a/tests/Estina/SmartFocus/Tests/Api/Rest/NotificationTest.php
+++ b/tests/Estina/SmartFocus/Tests/Api/Rest/NotificationTest.php
@@ -4,18 +4,20 @@ namespace Estina\SmartFocus\Tests;
 
 use PHPUnit_Framework_TestCase;
 use ReflectionProperty;
-
 use Estina\SmartFocus\Api\Rest\Notification;
+use SimpleXMLElement;
 
 /**
- * Notification REST Service test
+ * Notification REST Service test.
  *
  * @license MIT License (http://www.opensource.org/licenses/mit-license.php)
+ * @group notification
+ * @group unit
  */
 class NotificationTest extends PHPUnit_Framework_TestCase
 {
     /**
-     * Tests send
+     * Tests send.
      */
     public function testSend()
     {
@@ -30,7 +32,6 @@ class NotificationTest extends PHPUnit_Framework_TestCase
         $client->expects($this->once())
                ->method('get');
         $response = $service->send($email, $encrypt, $notificationId, $random, $dyn);
-
     }
 
     /**
@@ -60,5 +61,172 @@ class NotificationTest extends PHPUnit_Framework_TestCase
         return $refl->getValue($object);
     }
 
+    /**
+     * testPost Test that post executes as expected.
+     */
+    public function testPost()
+    {
+        // Prepare / Mock
+        $service = $this->getService();
+        $xmlObjectMock = new SimpleXMLElement('<request></request>');
 
+        $client = $this->getHiddenProperty($service, 'client');
+        $client->expects($this->once())
+               ->method('post')
+               ->with($this->isType('string'), $this->isType('string'))
+               ->will($this->returnValue('success'));
+
+        // Execute
+        $result = $service->post($xmlObjectMock);
+
+        // Assert Result
+        $this->assertEquals('success', $result);
+    }
+
+    /**
+     * Test that buildTransactionalRequestObject works as expected.
+     */
+    public function testBuildTransactionalRequestObjectWithoutDynAndContent()
+    {
+        $service = $this->getService();
+        $params = [
+            'encrypt' => 'asdf',
+            'random' => 'asdjhfk',
+            'email' => 'real@email.com',
+            'send_date' => '10.05.2016',
+            'synchro_type' => 'xml',
+            'uid_key' => '271162'
+        ];
+
+        $result = $service->buildTransactionalRequestObject($params);
+
+        $this->assertInstanceOf(SimpleXMLElement::class, $result);
+        $this->assertFalse(property_exists($result->sendrequest, 'dyn'));
+        $this->assertFalse(property_exists($result->sendrequest, 'content'));
+    }
+
+    /**
+     * Test that buildTransactionalRequestObject works as expected.
+     */
+    public function testBuildTransactionalRequestObjectWithDyn()
+    {
+        $service = $this->getService();
+        $params = [
+            'encrypt' => 'asdf',
+            'random' => 'asdjhfk',
+            'email' => 'real@email.com',
+            'send_date' => '10.05.2016',
+            'synchro_type' => 'xml',
+            'uid_key' => '271162'
+        ];
+        $dyn = [
+            'name' => 'Abdul',
+            'email' => 'abdul@easyfundraising.org.uk'
+        ];
+
+        $result = $service->buildTransactionalRequestObject($params, $dyn);
+
+        $this->assertInstanceOf(SimpleXMLElement::class, $result);
+        $this->assertInstanceOf(SimpleXMLElement::class, $result->sendrequest->dyn);
+        $this->assertEquals($result->sendrequest->dyn->entry[0]->key, 'name');
+        $this->assertEquals($result->sendrequest->dyn->entry[0]->value, 'Abdul');
+        $this->assertEquals($result->sendrequest->dyn->entry[1]->key, 'email');
+        $this->assertEquals($result->sendrequest->dyn->entry[1]->value, 'abdul@easyfundraising.org.uk');
+
+        $this->assertFalse(property_exists($result->sendrequest, 'content'));
+    }
+
+    /**
+     * Test that buildTransactionalRequestObject works as expected.
+     */
+    public function testBuildTransactionalRequestObjectWithDynAndContentAndTracking()
+    {
+        $service = $this->getService();
+        $params = [
+            'encrypt' => 'asdf',
+            'random' => 'asdjhfk',
+            'email' => 'real@email.com',
+            'send_date' => '10.05.2016',
+            'synchro_type' => 'xml',
+            'uid_key' => '271162'
+        ];
+        $dyn = [
+            'name' => 'Abdul',
+            'email' => 'abdul@easyfundraising.org.uk'
+        ];
+        $content = [
+            'click <a href="https://track.this/up?enabled=true">here</a>',
+            "click <a href='https://track.this/up?enabled=true&index=2#stuff'>here 2</a>",
+            'image <img src="https://dont.track/this?up=false">'
+        ];
+
+        $result = $service->buildTransactionalRequestObject($params, $dyn, $content, true);
+        $result2 = $service->buildTransactionalRequestObject($params, $dyn, $content);
+
+        // Assert the default is not true for tracking.
+        $this->assertNotEquals($result, $result2);
+
+        $this->assertInstanceOf(SimpleXMLElement::class, $result);
+        $this->assertInstanceOf(SimpleXMLElement::class, $result->sendrequest->dyn);
+        $this->assertEquals($result->sendrequest->dyn->entry[0]->key, 'name');
+        $this->assertEquals($result->sendrequest->dyn->entry[0]->value, 'Abdul');
+        $this->assertEquals($result->sendrequest->dyn->entry[1]->key, 'email');
+        $this->assertEquals($result->sendrequest->dyn->entry[1]->value, 'abdul@easyfundraising.org.uk');
+
+        $this->assertInstanceOf(SimpleXMLElement::class, $result->sendrequest->content);
+        $this->assertTrue(property_exists($result->sendrequest, 'content'));
+        // Emv tags added.
+        $this->assertEquals($result->sendrequest->content->entry[0]->value, 'click <a href="[EMV URL]https://track.this/up?enabled=true[EMV /URL]">here</a>');
+        // Emv tags added.
+        $this->assertEquals($result->sendrequest->content->entry[1]->value, "click <a href='[EMV URL]https://track.this/up?enabled=true&index=2#stuff[EMV /URL]'>here 2</a>");
+        // Unchanged.
+        $this->assertEquals($result->sendrequest->content->entry[2]->value, 'image <img src="https://dont.track/this?up=false">');
+    }
+
+    /**
+     * Test that buildTransactionalRequestObject works as expected.
+     */
+    public function testBuildTransactionalRequestObjectWithDynAndContentAndWithoutTracking()
+    {
+        $service = $this->getService();
+        $params = [
+            'encrypt' => 'asdf',
+            'random' => 'asdjhfk',
+            'email' => 'real@email.com',
+            'send_date' => '10.05.2016',
+            'synchro_type' => 'xml',
+            'uid_key' => '271162'
+        ];
+        $dyn = [
+            'name' => 'Abdul',
+            'email' => 'abdul@easyfundraising.org.uk'
+        ];
+        $content = [
+            'click <a href="https://track.this/up?enabled=true">here</a>',
+            "click <a href='https://track.this/up?enabled=true&index=2#stuff'>here 2</a>",
+            'image <img src="https://dont.track/this?up=false">'
+        ];
+
+        $result = $service->buildTransactionalRequestObject($params, $dyn, $content, false);
+        $result2 = $service->buildTransactionalRequestObject($params, $dyn, $content);
+
+        // Assert the default is false for tracking.
+        $this->assertEquals($result, $result2);
+
+        $this->assertInstanceOf(SimpleXMLElement::class, $result);
+        $this->assertInstanceOf(SimpleXMLElement::class, $result->sendrequest->dyn);
+        $this->assertEquals($result->sendrequest->dyn->entry[0]->key, 'name');
+        $this->assertEquals($result->sendrequest->dyn->entry[0]->value, 'Abdul');
+        $this->assertEquals($result->sendrequest->dyn->entry[1]->key, 'email');
+        $this->assertEquals($result->sendrequest->dyn->entry[1]->value, 'abdul@easyfundraising.org.uk');
+
+        $this->assertInstanceOf(SimpleXMLElement::class, $result->sendrequest->content);
+        $this->assertTrue(property_exists($result->sendrequest, 'content'));
+        // Emv tags added.
+        $this->assertEquals($result->sendrequest->content->entry[0]->value, 'click <a href="https://track.this/up?enabled=true">here</a>');
+        // Emv tags added.
+        $this->assertEquals($result->sendrequest->content->entry[1]->value, "click <a href='https://track.this/up?enabled=true&index=2#stuff'>here 2</a>");
+        // Unchanged.
+        $this->assertEquals($result->sendrequest->content->entry[2]->value, 'image <img src="https://dont.track/this?up=false">');
+    }
 }

--- a/tests/Estina/SmartFocus/Tests/Api/Rest/NotificationTest.php
+++ b/tests/Estina/SmartFocus/Tests/Api/Rest/NotificationTest.php
@@ -89,16 +89,15 @@ class NotificationTest extends PHPUnit_Framework_TestCase
     public function testBuildTransactionalRequestObjectWithoutDynAndContent()
     {
         $service = $this->getService();
-        $params = [
-            'encrypt' => 'asdf',
-            'random' => 'asdjhfk',
-            'email' => 'real@email.com',
-            'send_date' => '10.05.2016',
-            'synchro_type' => 'xml',
-            'uid_key' => '271162'
-        ];
+        $email = 'real@email.com';
+        $encryptId = 'asdf';
+        $randomId = 'asdjhfk';
 
-        $result = $service->buildTransactionalRequestObject($params);
+        $result = $service->buildTransactionalRequestObject(
+            $email,
+            $encryptId,
+            $randomId
+        );
 
         $this->assertInstanceOf(SimpleXMLElement::class, $result);
         $this->assertFalse(property_exists($result->sendrequest, 'dyn'));
@@ -108,23 +107,30 @@ class NotificationTest extends PHPUnit_Framework_TestCase
     /**
      * Test that buildTransactionalRequestObject works as expected.
      */
-    public function testBuildTransactionalRequestObjectWithDyn()
+    public function testBuildTransactionalRequestObjectWithDynAndAdditionalParams()
     {
         $service = $this->getService();
-        $params = [
-            'encrypt' => 'asdf',
-            'random' => 'asdjhfk',
-            'email' => 'real@email.com',
-            'send_date' => '10.05.2016',
-            'synchro_type' => 'xml',
-            'uid_key' => '271162'
-        ];
+
+        $email = 'real@email.com';
+        $encryptId = 'asdf';
+        $randomId = 'asdjhfk';
+
         $dyn = [
             'name' => 'Abdul',
             'email' => 'abdul@easyfundraising.org.uk'
         ];
 
-        $result = $service->buildTransactionalRequestObject($params, $dyn);
+        $additionalParams = array('senddate' => '10.05.2016', 'stuff' => 'xyz');
+
+        $result = $service->buildTransactionalRequestObject(
+            $email,
+            $encryptId,
+            $randomId,
+            $dyn,
+            null,
+            false,
+            $additionalParams
+        );
 
         $this->assertInstanceOf(SimpleXMLElement::class, $result);
         $this->assertInstanceOf(SimpleXMLElement::class, $result->sendrequest->dyn);
@@ -134,6 +140,9 @@ class NotificationTest extends PHPUnit_Framework_TestCase
         $this->assertEquals($result->sendrequest->dyn->entry[1]->value, 'abdul@easyfundraising.org.uk');
 
         $this->assertFalse(property_exists($result->sendrequest, 'content'));
+        $this->assertTrue(property_exists($result->sendrequest, 'senddate'));
+        $this->assertEquals($result->sendrequest->senddate, '10.05.2016');
+        $this->assertEquals($result->sendrequest->stuff, 'xyz');
     }
 
     /**
@@ -142,10 +151,12 @@ class NotificationTest extends PHPUnit_Framework_TestCase
     public function testBuildTransactionalRequestObjectWithDynAndContentAndTracking()
     {
         $service = $this->getService();
+
+        $email = 'real@email.com';
+        $encryptId = 'asdf';
+        $randomId = 'asdjhfk';
+
         $params = [
-            'encrypt' => 'asdf',
-            'random' => 'asdjhfk',
-            'email' => 'real@email.com',
             'send_date' => '10.05.2016',
             'synchro_type' => 'xml',
             'uid_key' => '271162'
@@ -160,11 +171,7 @@ class NotificationTest extends PHPUnit_Framework_TestCase
             'image <img src="https://dont.track/this?up=false">'
         ];
 
-        $result = $service->buildTransactionalRequestObject($params, $dyn, $content, true);
-        $result2 = $service->buildTransactionalRequestObject($params, $dyn, $content);
-
-        // Assert the default is not true for tracking.
-        $this->assertNotEquals($result, $result2);
+        $result = $service->buildTransactionalRequestObject($email, $encryptId, $randomId, $dyn, $content, true, $params);
 
         $this->assertInstanceOf(SimpleXMLElement::class, $result);
         $this->assertInstanceOf(SimpleXMLElement::class, $result->sendrequest->dyn);
@@ -189,14 +196,11 @@ class NotificationTest extends PHPUnit_Framework_TestCase
     public function testBuildTransactionalRequestObjectWithDynAndContentAndWithoutTracking()
     {
         $service = $this->getService();
-        $params = [
-            'encrypt' => 'asdf',
-            'random' => 'asdjhfk',
-            'email' => 'real@email.com',
-            'send_date' => '10.05.2016',
-            'synchro_type' => 'xml',
-            'uid_key' => '271162'
-        ];
+
+        $email = 'real@email.com';
+        $encryptId = 'asdf';
+        $randomId = 'asdjhfk';
+
         $dyn = [
             'name' => 'Abdul',
             'email' => 'abdul@easyfundraising.org.uk'
@@ -207,8 +211,8 @@ class NotificationTest extends PHPUnit_Framework_TestCase
             'image <img src="https://dont.track/this?up=false">'
         ];
 
-        $result = $service->buildTransactionalRequestObject($params, $dyn, $content, false);
-        $result2 = $service->buildTransactionalRequestObject($params, $dyn, $content);
+        $result = $service->buildTransactionalRequestObject($email, $encryptId, $randomId, $dyn, $content, false);
+        $result2 = $service->buildTransactionalRequestObject($email, $encryptId, $randomId, $dyn, $content);
 
         // Assert the default is false for tracking.
         $this->assertEquals($result, $result2);

--- a/tests/phpunit.xml.dist
+++ b/tests/phpunit.xml.dist
@@ -2,7 +2,7 @@
 
 <phpunit backupGlobals="false"
          backupStaticAttributes="false"
-         bootstrap="vendor/autoload.php"
+         bootstrap="../vendor/autoload.php"
          colors="true"
          convertErrorsToExceptions="true"
          convertNoticesToExceptions="true"
@@ -14,7 +14,7 @@
 
     <testsuites>
         <testsuite name="Estina SmartFocus Test Suit">
-            <directory>./tests/</directory>
+            <directory>../tests/</directory>
         </testsuite>
     </testsuites>
 


### PR DESCRIPTION
Requirements arose from having to send smartfocus dynamic content blocks which have html in them. The only way to do this is to build up an xml object and post it. More documentation available here https://help-developer.smartfocus.com/Content/PDF/SmartFocus_API__NMP_TEMPLATES_REST_.pdf