### PR TITLE
Updated invalid api url

### DIFF
--- a/src/Estina/SmartFocus/Api/Rest/Member.php
+++ b/src/Estina/SmartFocus/Api/Rest/Member.php
@@ -270,7 +270,7 @@ class Member extends AbstractRestService
     public function getMembersByPage($token, $page)
     {
         $response = $this->client->get(
-            $this->getUrl("member/getListMembersByPage/$token/$page")
+            $this->getUrl("getListMembersByPage/$token/$page")
         );
 
         return $response;


### PR DESCRIPTION
The getMembersByPage url is incorrect. It should be `getListMembersByPage/$token/$page` instead of `member/getListMembersByPage/$token/$page`